### PR TITLE
[WIP]商品詳細表示機能実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,15 +5,15 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [
-                                                        :nickname,
-                                                        :firstname,
-                                                        :lastname,
-                                                        :firstname_kana,
-                                                        :lastname_kana,
-                                                        :password,
-                                                        :encrypted_password,
-                                                        :birthday
-                                                        ])
+                                        :nickname,
+                                        :firstname,
+                                        :lastname,
+                                        :firstname_kana,
+                                        :lastname_kana,
+                                        :password,
+                                        :encrypted_password,
+                                        :birthday
+                                      ])
   end
 
   # before_action :authenticate_user!

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index]
+  before_action :move_to_index, except: [:index, :show]
   def index
     @items = Item.all
   end
@@ -12,6 +12,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
   def create

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,6 +18,6 @@ class Item < ApplicationRecord
     validates :condition_id, numericality: { other_than: 1 }
     validates :delivery_id, numericality: { other_than: 1 }
     validates :postage_id, numericality: { other_than: 1 }
-    validates :price, numericality: { greater_than_or_equal_to: 300, less_than: 9_999_999 }
+    validates :price, numericality: { greater_than_or_equal_to: 300, less_than: 10_000_000 }
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,6 +18,6 @@ class Item < ApplicationRecord
     validates :condition_id, numericality: { other_than: 1 }
     validates :delivery_id, numericality: { other_than: 1 }
     validates :postage_id, numericality: { other_than: 1 }
-    validates :price, numericality: { greater_than_or_equal_to: 300, less_than: 10_000_000 }
+    validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |i| %>
         <li class='list'>
-          <%= link_to item_path(i.id), method: :get do %>
+          <%= link_to item_path(i.id) do %>
           <div class='item-img-content'>
             <%= image_tag i.image, class: "item-img" %> 
 
@@ -157,7 +157,6 @@
           <% end %>
         </li>
       <% end %>
-    
       
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |i| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(i.id), method: :get do %>
           <div class='item-img-content'>
             <%= image_tag i.image, class: "item-img" %> 
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,65 +4,68 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sould outの表示をしましょう。 %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
+      <% if @item.purchase %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
       <%# //商品が売れている場合は、sould outの表示をしましょう。 %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
       </span>
     </div>
-
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+   
+    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物であるとき表示しましょう。 %>
+    <% if user_signed_in? && @item.user == current_user %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
+    <% if user_signed_in? && @item.user != current_user %>
+      <% unless @item.purchase %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
+    <% end %>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.information %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery.name %></td>
         </tr>
       </tbody>
     </table>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,80 +1,90 @@
 require 'rails_helper'
 
 RSpec.describe Item, type: :model do
+  before do
+    @item = build(:item)
+  end
+
   it 'is valid with a name, image, information, category, condition, delivery, postage, prefecture, price' do
-    item = build(:item)
-    expect(item).to be_valid
+    expect(@item).to be_valid
   end
 
   it 'is invalid without name' do
-    item = build(:item, name: '')
-    item.valid?
-    expect(item.errors[:name]).to include("can't be blank")
+    @item.name = nil
+    @item.valid?
+    expect(@item.errors[:name]).to include("can't be blank")
   end
 
   it 'is invalid without image' do
-    item = build(:item, image: nil)
-    item.valid?
-    expect(item.errors[:image]).to include("can't be blank")
+    @item.image = nil
+    @item.valid?
+
+    expect(@item.errors[:image]).to include("can't be blank")
   end
 
   it 'is invalid without information' do
-    item = build(:item, information: '')
-    item.valid?
-    expect(item.errors[:information]).to include("can't be blank")
+    @item.information = nil
+    @item.valid?
+    expect(@item.errors[:information]).to include("can't be blank")
   end
 
   it 'is invalid without category' do
-    item = build(:item, category_id: '')
-    item.valid?
-    expect(item.errors[:category_id]).to include("can't be blank")
+    @item.category_id = nil
+    @item.valid?
+    expect(@item.errors[:category_id]).to include("can't be blank")
   end
 
   it 'is invalid without condition_id' do
-    item = build(:item, condition_id: '')
-    item.valid?
-    expect(item.errors[:condition_id]).to include("can't be blank")
+    @item.condition_id = nil
+    @item.valid?
+    expect(@item.errors[:condition_id]).to include("can't be blank")
   end
 
   it 'is invalid without delivery_id' do
-    item = build(:item, delivery_id: '')
-    item.valid?
-    expect(item.errors[:delivery_id]).to include("can't be blank")
+    @item.delivery_id = nil
+    @item.valid?
+    expect(@item.errors[:delivery_id]).to include("can't be blank")
   end
 
   it 'is invalid without postage_id' do
-    item = build(:item, postage_id: '')
-    item.valid?
-    expect(item.errors[:postage_id]).to include("can't be blank")
+    @item.postage_id = nil
+    @item.valid?
+    expect(@item.errors[:postage_id]).to include("can't be blank")
   end
 
   it 'is invalid without prefecture_id' do
-    item = build(:item, prefecture_id: '')
-    item.valid?
-    expect(item.errors[:prefecture_id]).to include("can't be blank")
+    @item.prefecture_id = nil
+    @item.valid?
+    expect(@item.errors[:prefecture_id]).to include("can't be blank")
   end
 
   it 'is invalid without price' do
-    item = build(:item, price: '')
-    item.valid?
-    expect(item.errors[:price]).to include("can't be blank")
+    @item.price = nil
+    @item.valid?
+    expect(@item.errors[:price]).to include("can't be blank")
   end
 
   it 'is invalid price that has more than 10000000' do
-    item = build(:item, price: '10000000')
-    item.valid?
-    expect(item.errors[:price]).to include('must be less than 9999999')
+    @item.price = 10_000_000
+    @item.valid?
+    expect(@item.errors[:price]).to include('must be less than 10000000')
   end
 
   it 'is invalid price that has less than 299' do
-    item = build(:item, price: '299')
-    item.valid?
-    expect(item.errors[:price]).to include('must be greater than or equal to 300')
+    @item.price = 299
+    @item.valid?
+    expect(@item.errors[:price]).to include('must be greater than or equal to 300')
   end
 
-  it 'is valid price that has more than ' do
-    item = build(:item, price: '9999999')
-    item.valid?
-    expect(item.errors[:price]).to include('must be less than 9999999')
+  it 'is valid price that has less than 9999999 ' do
+    @item.price = 9_999_999
+    @item.valid?
+    expect(@item).to be_valid
+  end
+
+  it 'is valid price that has more than 300 ' do
+    @item.price = 300
+    @item.valid?
+    expect(@item).to be_valid
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Item, type: :model do
   it 'is valid with a name, image, information, category, condition, delivery, postage, prefecture, price' do
     item = build(:item)
+    binding.pry
     expect(item).to be_valid
   end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe Item, type: :model do
   it 'is valid with a name, image, information, category, condition, delivery, postage, prefecture, price' do
     item = build(:item)
-    binding.pry
     expect(item).to be_valid
   end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -64,10 +64,10 @@ RSpec.describe Item, type: :model do
     expect(@item.errors[:price]).to include("can't be blank")
   end
 
-  it 'is invalid price that has more than 10000000' do
+  it 'is invalid price that has more than 10,000,000' do
     @item.price = 10_000_000
     @item.valid?
-    expect(@item.errors[:price]).to include('must be less than 10000000')
+    expect(@item.errors[:price]).to include('must be less than or equal to 9999999')
   end
 
   it 'is invalid price that has less than 299' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,133 +2,126 @@ require 'rails_helper'
 
 describe User do
   describe '#create' do
+    before do
+      @user = build(:user)
+    end
     it 'is valid with a nickname, firstname,lastname,firstname_kana,lastname_kana,email, password, password_confirmation' do
-      user = build(:user)
-      expect(user).to be_valid
+      expect(@user).to be_valid
     end
 
     it 'is invalid without a nickname' do
-      user = build(:user, nickname: '')
-      user.valid?
-      expect(user.errors[:nickname]).to include("can't be blank")
+      @user.nickname = nil
+      @user.valid?
+      expect(@user.errors[:nickname]).to include("can't be blank")
     end
 
     it 'is invalid without a email' do
-      user = build(:user, email: '')
-      user.valid?
-      expect(user.errors[:email]).to include("can't be blank")
+      @user.email = nil
+      @user.valid?
+      expect(@user.errors[:email]).to include("can't be blank")
     end
 
     it 'is invalid without firstname' do
-      user = build(:user, firstname: '')
-      user.valid?
-      expect(user.errors[:firstname]).to include("can't be blank")
+      @user.firstname = nil
+      @user.valid?
+      expect(@user.errors[:firstname]).to include("can't be blank")
     end
 
     it 'is invalid without lastname' do
-      user = build(:user, lastname: '')
-      user.valid?
-      expect(user.errors[:lastname]).to include("can't be blank")
+      @user.lastname = nil
+      @user.valid?
+      expect(@user.errors[:lastname]).to include("can't be blank")
     end
 
     it 'is invalid without firstname_kana' do
-      user = build(:user, firstname_kana: '')
-      user.valid?
-      expect(user.errors[:firstname_kana]).to include("can't be blank")
+      @user.firstname_kana = nil
+      @user.valid?
+      expect(@user.errors[:firstname_kana]).to include("can't be blank")
     end
 
     it 'is invalid without lastname_kana' do
-      user = build(:user, lastname_kana: '')
-      user.valid?
-      expect(user.errors[:lastname_kana]).to include("can't be blank")
+      @user.lastname_kana = nil
+      @user.valid?
+      expect(@user.errors[:lastname_kana]).to include("can't be blank")
     end
 
     it 'is invalid without password' do
-      user = build(:user, password: '')
-      user.valid?
-      expect(user.errors[:password]).to include("can't be blank")
+      @user.password = nil
+      @user.valid?
+      expect(@user.errors[:password]).to include("can't be blank")
     end
 
     it 'is invalid without password_confirmation' do
-      user = build(:user, password_confirmation: '')
-      user.valid?
-      expect(user.errors[:password_confirmation]).to include("can't be blank")
+      @user.password_confirmation = nil
+      @user.valid?
+      expect(@user.errors[:password_confirmation]).to include("can't be blank")
     end
 
     it 'is invalid without birthday ' do
-      user = build(:user, birthday: '')
-      user.valid?
-      expect(user.errors[:birthday]).to include("can't be blank")
+      @user.birthday = nil
+      @user.valid?
+      expect(@user.errors[:birthday]).to include("can't be blank")
     end
 
     it 'is invalid firstname hankaku ' do
-      user = build(:user, firstname: 'name1')
-      user.valid?
-      expect(user.errors[:firstname]).to include('is invalid')
+      @user.firstname = 'taro'
+      @user.valid?
+      expect(@user.errors[:firstname]).to include('is invalid')
     end
 
     it 'is invalid lastname hankaku ' do
-      user = build(:user, lastname: 'name1')
-      user.valid?
-      expect(user.errors[:lastname]).to include('is invalid')
+      @user.lastname = 'suzuki'
+      @user.valid?
+      expect(@user.errors[:lastname]).to include('is invalid')
     end
 
     it 'is invalid firstname_kana hankaku,zenkaku-kanji,zenkaku-hiragana ' do
-      user = build(:user, firstname_kana: 'name1')
-      user.valid?
-      expect(user.errors[:firstname_kana]).to include('is invalid')
+      @user.firstname_kana = '太朗'
+      @user.valid?
+      expect(@user.errors[:firstname_kana]).to include('is invalid')
     end
 
     it 'is invalid lastname_kana hankaku,zenkaku-kanji,zenkaku-hiragana ' do
-      user = build(:user, lastname_kana: 'name')
-      user.valid?
-      expect(user.errors[:lastname_kana]).to include('is invalid')
+      @user.lastname_kana = '鈴木'
+      @user.valid?
+      expect(@user.errors[:lastname_kana]).to include('is invalid')
     end
 
     it 'is invalid without a password_confirmation although with a password' do
-      user = build(:user, password_confirmation: 'fff1122')
-      user.valid?
-      expect(user.errors[:password_confirmation]).to include("doesn't match Password")
+      @user.password = 'fff1122'
+      @user.valid?
+      expect(@user.errors[:password_confirmation]).to include("doesn't match Password")
     end
 
     it 'is invalid with  that has less than 5 characters ' do
-      user = build(:user, password: '111aa')
-      user.valid?
-      expect(user.errors[:password]).to include('is invalid')
+      @user.password = '111aa'
+      @user.valid?
+      expect(@user.errors[:password]).to include('is invalid')
     end
 
     it 'is valid with that has more than 6 characters ' do
-      user = build(:user, password: '111aaa')
-      expect(user).to be_valid
+      @user.password = '111aaa'
+      expect(@user).to be_valid
     end
 
-    it 'is invalid with that has less than 5 characters ' do
-      user = build(:user, password_confirmation: '111aa')
-      user.valid?
-      expect(user.errors[:password_confirmation]).to include('is invalid')
+    it 'is invalid only number ' do
+      @user.password = '111111'
+      @user.valid?
+      expect(@user.errors[:password]).to include('is invalid')
     end
 
-    it 'is valid with that has more than 6 characters ' do
-      user = build(:user, password_confirmation: '111aaa')
-      expect(user).to be_valid
-    end
-    it 'is invalid both number and alphabet ' do
-      user = build(:user, password: '111111')
-      user.valid?
-      expect(user.errors[:password]).to include('is invalid')
+    it 'is invalid without @' do
+      @user.email = 'aaaaaa.com'
+      @user.valid?
+      expect(@user.errors[:email]).to include('is invalid')
     end
 
     it 'is invalid with a duplicate email address' do
       user = create(:user)
-      another_user = build(:user, email: user.email)
+      another_user = @user.dup
+      @user.save
       another_user.valid?
       expect(another_user.errors[:email]).to include('has already been taken')
-    end
-
-    it 'is invalid without @' do
-      user = build(:user, email: 'aaaaaaaaaa')
-      user.valid?
-      expect(user.errors[:email]).to include('is invalid')
     end
   end
 end


### PR DESCRIPTION
# What
・商品画像をクリックすると、その詳細ページに飛べるように実装した。
・ログアウト状態でも詳細は見れるようにしたが、商品購入ボタンは現れないようにした。
・出品者にのみ編集・削除ボタンが現れるようにした。
・ログインしている出品者ではないユーザーだけに購入ボタンが現れるようにした。
・売り切れ時はボタンが表示されないようにした。
# Why
・ログアウト状態では購入は不可能であるため。
・出品者が購入行為をすることは通常ありえないため。
# gyazo URL
「出品者」
https://gyazo.com/344d611f84fc14d6f96c5ca263b1a14a
「ログインユーザー」
https://gyazo.com/e5243119d91c3f016855688394c7d4f1
「ログアウト」
https://gyazo.com/48498ac8dd7b1bcaae06cb19a0b23fb1
「売り切れ」
https://gyazo.com/a73ec9e8efa3cb1c8fa82d515c30a815